### PR TITLE
Add `output.log` to `.distignore`

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,6 +10,7 @@
 .eslintrc.js
 DOCKER_ENV
 docker_tag
+output.log
 phpcs.xml
 phpmd.xml
 phpstan.neon


### PR DESCRIPTION
Our GitHub Actions workflow automatically generates the `output.log` file, which we don’t have to push to the Plugin Directory. Added that to `.distignore`.