### PR TITLE
Fixing emojis rendering.

### DIFF
--- a/includes/Client/Cookie_Consent.php
+++ b/includes/Client/Cookie_Consent.php
@@ -38,7 +38,7 @@ class Cookie_Consent implements Actions, Filters {
      * @param Settings $settings_object An instance of the `Settings` class.
      */
     public function __construct( Settings $settings_object ) {
-        $this->settings = $settings_object->get();
+        $this->settings = $settings_object->get( false );
     }
 
     /**

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -186,7 +186,7 @@ class Settings {
         $settings = $this->options->get( self::OPTIONS_KEY );
 
         if ( ! empty( $settings ) ) {
-            return $settings;
+            return Utils::decode_emoji_array( $settings );
         }
 
         return $this->get_default_values();

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -180,13 +180,20 @@ class Settings {
     /**
      * Return settings.
      *
+     * @param bool $decodeEmoji
+     *
      * @return array
      */
-    public function get(): array {
+    public function get(bool $decodeEmoji = true): array
+    {
         $settings = $this->options->get( self::OPTIONS_KEY );
 
-        if ( ! empty( $settings ) ) {
-            return Utils::decode_emoji_array( $settings );
+        if( !empty( $settings ) ) {
+
+            if( $decodeEmoji )
+                return Utils::decode_emoji_array( $settings );
+
+            return $settings;
         }
 
         return $this->get_default_values();

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -173,4 +173,124 @@ class Utils {
         return $encoded;
     }
 
+
+    /**
+     * Decode emoji characters in a nested array.
+     * This method takes an array as input and iterates through its elements. If an element is a string, it checks
+     * whether it contains any emoji characters. If so, it replaces those emoji characters with their respective
+     * HTML entities. If the element is an array, it recursively calls the method to decode emoji characters in
+     * the nested array.
+     *
+     * @param array $arr The input array containing strings and/or nested arrays.
+     *
+     * @return array The input array with emoji characters replaced by their respective HTML entities.
+     */
+    public static function decode_emoji_array(array $arr): array
+    {
+        $encoded = [];
+
+        foreach($arr as $key => $value) {
+            if( is_array( $value ) ) {
+                $encoded[$key] = self::decode_emoji_array( $value );
+                continue;
+            }
+
+            if( is_string( $value ) )
+                $value = self::staticize_emoji( $value );
+
+            $encoded[$key] = $value;
+        }
+
+        return $encoded;
+    }
+
+    /**
+     * Staticize emoji characters in a given text.
+     * This method checks the input text for emoji characters and replaces them with their respective HTML entities.
+     * It utilizes the WordPress `wp_encode_emoji()` function to encode emoji characters in the text. Before encoding,
+     * it quickly narrows down the list of emojis that might be present in the text and need replacement. If the text
+     * doesn't contain any characters that might be emojis, it returns the input text as it is.
+     *
+     * @param string $text The input text to be checked for emoji characters.
+     *
+     * @return string The input text with emoji characters replaced by their respective HTML entities.
+     */
+    protected static function staticize_emoji(string $text): string
+    {
+        // If the text does not contain '&#x', there is no need to check for emojis, so we can return the input text early.
+        if( !str_contains( $text, '&#x' ) ) {
+            // Check if the text is ASCII or contains only standard ASCII characters using mb_check_encoding().
+            // If true, it means the text doesn't contain any emoji characters.
+            if( ( function_exists( 'mb_check_encoding' ) && mb_check_encoding( $text, 'ASCII' ) ) || !preg_match( '/[^\x00-\x7F]/', $text ) ) {
+                // The text doesn't contain anything that might be an emoji, so we can return early.
+                return $text;
+            } else {
+                // Encode any emoji characters in the text using the wp_encode_emoji() function.
+                $encoded_text = wp_encode_emoji( $text );
+                if( $encoded_text === $text ) {
+                    // If the encoded text is the same as the original text, it means there were no emoji characters to encode.
+                    return $encoded_text;
+                }
+                $text = $encoded_text;
+            }
+        }
+
+        // Get a list of emoji entities using the _wp_emoji_list('entities') function.
+        $emoji = _wp_emoji_list( 'entities' );
+
+        // Quickly narrow down the list of emoji that might be in the text and need replacing.
+        $possible_emoji = [];
+        foreach($emoji as $emojum) {
+            if( str_contains( $text, $emojum ) ) {
+                // If the text contains this emoji, add it to the list of possible emoji for replacement.
+                $possible_emoji[$emojum] = html_entity_decode( $emojum );
+            }
+        }
+
+        // If there are no possible emoji for replacement, return the original text.
+        if( !$possible_emoji )
+            return $text;
+
+        $output = '';
+
+        /*
+         * HTML loop taken from smiley function, which was taken from texturize function.
+         * It'll never be consolidated.
+         *
+         * First, capture the tags as well as the content in between.
+         */
+        $textarr = preg_split( '/(<.*>)/U', $text, -1, PREG_SPLIT_DELIM_CAPTURE );
+        $stop = count( $textarr );
+
+        // Ignore processing of specific tags.
+        $tags_to_ignore = 'code|pre|style|script|textarea';
+        $ignore_block_element = '';
+
+        for($i = 0; $i < $stop; $i++) {
+            $content = $textarr[$i];
+
+            // If we're in an ignore block, wait until we find its closing tag.
+            if( '' === $ignore_block_element && preg_match( '/^<(' . $tags_to_ignore . ')>/', $content, $matches ) )
+                $ignore_block_element = $matches[1];
+
+            // If it's not a tag and not in an ignore block, and it contains emoji entities, replace the emoji with their HTML entities.
+            if( '' === $ignore_block_element && strlen( $content ) > 0 && '<' !== $content[0] && str_contains( $content, '&#x' ) ) {
+                foreach($possible_emoji as $emojum => $emoji_char) {
+                    if( !str_contains( $content, $emojum ) )
+                        continue;
+                    $content = str_replace( $emojum, $emoji_char, $content );
+                }
+            }
+
+            // Did we exit the ignore block?
+            if( '' !== $ignore_block_element && '</' . $ignore_block_element . '>' === $content )
+                $ignore_block_element = '';
+
+            $output .= $content;
+        }
+
+        // Finally, remove any stray U+FE0F characters.
+        return str_replace( '&#xfe0f;', '', $output );
+    }
+
 }


### PR DESCRIPTION
### Issue Description:

In the previous implementation, when storing emojis in the database, they were saved in the utf8 character set (e.g., `&#x1f4e2;`). However, when attempting to display these emojis within an input or textarea field, they were still being shown as "`&#x1f4e2;`" instead of the actual emoji representation.

![Fixing emojis rendering](https://github.com/pressidium/pressidium-cookie-consent/assets/12151806/ddde2f0e-ec58-407b-ad8c-1c80973b3877)


### Changes Made:

To fix the emoji display issue, two changes were implemented:

Updated Settings.php: The `get()` method in **Settings.php** was modified to handle decoding emoji arrays. Now, before returning the settings, the method calls `Utils::decode_emoji_array($settings)` to ensure that any emoji characters in the settings array are properly decoded.

To fix the emoji display issue, two new functions were added to the existing **Utils.php** file:

`decode_emoji_array()`: This function is responsible for decoding emoji characters in a nested array. It iterates through the elements of the input array and, if an element is a string containing emoji characters, it replaces them with their respective HTML entities. If an element is another array, the function recursively calls itself to handle nested arrays.

`staticize_emoji()`: This function is used to check a given text for emoji characters and replace them with their respective HTML entities. Before encoding, the function first checks if the text contains any characters that might be emojis. If not, it returns the input text as it is. If emoji characters are present, the function uses WordPress' wp_encode_emoji() function to encode them. It also narrows down the list of emojis that might be in the text for more efficient processing. The function then iterates through the text and replaces the possible emojis with their corresponding HTML entities.