### PR TITLE
Fixed the "Multiple primary key defined" error on plugin reactivation

### DIFF
--- a/includes/Database/Table.php
+++ b/includes/Database/Table.php
@@ -67,6 +67,26 @@ abstract class Table {
     abstract public function get_version(): string;
 
     /**
+     * Checks if a table exists in the database.
+     *
+     * @param string $table_name The name of the table to check.
+     *
+     * @return bool True if the table exists, false if it doesn't.
+     */
+    private function table_exists(string $table_name): bool
+    {
+        global $wpdb;
+
+        // Use the $wpdb->get_var method to execute a SQL query to check for the table's existence.
+        $result = $wpdb->get_var(
+            $wpdb->prepare( "SHOW TABLES LIKE %s", $table_name )
+        );
+
+        // If the result matches the provided table name, the table exists; otherwise, it doesn't.
+        return $result === $table_name;
+    }
+
+    /**
      * Return the table's prefix.
      *
      * @return string
@@ -268,8 +288,16 @@ abstract class Table {
             require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         }
 
+        // Get the table name
+        $table_name = $this->prefix . $this->get_table_slug();
+
+        // Check if the table already exists
+        if( $this->table_exists( $table_name ) ) {
+            return; // Table already exists, do nothing
+        }
+
         $schema = Schema::create(
-            $this->prefix . $this->get_table_slug(),
+            $table_name,
             $this->charset_collate,
             function( Blueprint $table ) {
                 $this->get_table_schema( $table );


### PR DESCRIPTION
Prior to this commit, when reactivating the plugin, a SQL error occurred due to the attempt to redefine a primary key. The error was specifically caused by the ALTER TABLE statement trying to change the primary key of the "pressidium_cookie_consents" table, which already existed in the database.

![Multiple primary key defined](https://github.com/pressidium/pressidium-cookie-consent/assets/12151806/dee27068-ce92-4af1-aeb7-ac23daaae115)

To resolve this issue, a check was implemented to verify the existence of the table before attempting any alterations. The new table_exists method was added to the codebase. Now, when the `create` method is called, it first checks if the target table already exists in the database. If it does, the method exits gracefully, avoiding any conflicting SQL statements.

This modification ensures that the table is only created if it doesn't exist, preventing the "Multiple primary key defined" error on plugin reactivation.