### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Integrate with Google Consent Mode (GCM) to adjust how Google tags behave based 
 
 ### ✨ AI integration
 
-![AI screenshit](https://github.com/user-attachments/assets/f5771f7c-883b-4bcd-a440-e25889d3c751)
+![AI screenshot](https://github.com/user-attachments/assets/f5771f7c-883b-4bcd-a440-e25889d3c751)
 
 Integrate with AI to generate translations and cookie descriptions. Supports both GPT and Gemini.
 

--- a/includes/Admin/Settings/Settings_API.php
+++ b/includes/Admin/Settings/Settings_API.php
@@ -787,9 +787,9 @@ class Settings_API implements Actions {
      */
     private function maybe_migrate( array $settings ): array {
         $migrator          = new Migrator( $settings );
-        $mirgated_settings = $migrator->maybe_migrate();
+        $migrated_settings = $migrator->maybe_migrate();
 
-        return $mirgated_settings;
+        return $migrated_settings;
     }
 
     /**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -84,7 +84,7 @@
         <exclude name="WordPress.PHP.YodaConditions" />
 
         <!--
-         ... Warn about mis-aligned array items, but don't automatically "fix" them, because arrays in function
+         ... Warn about misaligned array items, but don't automatically "fix" them, because arrays in function
          ... calls get extra lines added.
 		 ...
 		 ... @see https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1305


### PR DESCRIPTION
Found few misspellings.

https://github.com/crate-ci/typos can run in a workflow.