### PR TITLE
1.8.1

### DIFF
--- a/includes/Client/Cookie_Consent.php
+++ b/includes/Client/Cookie_Consent.php
@@ -211,7 +211,7 @@ class Cookie_Consent implements Actions, Filters {
             function onPressidiumCookieConsentUpdated(event) {
                 window.dataLayer = window.dataLayer || [];
                 window.dataLayer.push({
-                    event: 'pressidium-cookie-consent-' + event.type,
+                    event: event.type,
                     consent: event.detail,
                 });
             }

--- a/includes/Client/Cookie_Consent.php
+++ b/includes/Client/Cookie_Consent.php
@@ -15,6 +15,7 @@ use Pressidium\WP\CookieConsent\Hooks\Actions;
 use Pressidium\WP\CookieConsent\Hooks\Filters;
 
 use Pressidium\WP\CookieConsent\Settings;
+use Pressidium\WP\CookieConsent\Utils\WP_Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
     die( 'Forbidden' );
@@ -94,6 +95,11 @@ class Cookie_Consent implements Actions, Filters {
      * @return void
      */
     public function enqueue_scripts(): void {
+        if ( WP_Utils::is_ninja_forms_preview() ) {
+            // Ninja Forms preview, do not enqueue scripts
+            return;
+        }
+
         $assets_file = PLUGIN_DIR . 'public/bundle.client.asset.php';
 
         if ( ! file_exists( $assets_file ) ) {

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -68,25 +68,11 @@ class Plugin {
     }
 
     /**
-     * Load plugin text domain.
-     *
-     * @return void
-     */
-    public function load_textdomain(): void {
-        load_plugin_textdomain(
-            'pressidium-cookie-consent',
-            false, // this parameter is deprecated
-            dirname( plugin_basename( __FILE__ ) ) . '/languages'
-        );
-    }
-
-    /**
      * Add WordPress hooks.
      *
      * @return void
      */
     private function add_hooks(): void {
-        add_action( 'init', array( $this, 'load_textdomain' ) );
         add_action( 'init', array( $this, 'register_blocks' ) );
     }
 

--- a/includes/Utils/WP_Utils.php
+++ b/includes/Utils/WP_Utils.php
@@ -36,4 +36,17 @@ class WP_Utils {
         return $domain;
     }
 
+    /**
+     * Whether the current request is a Ninja Forms preview.
+     *
+     * @since 1.9.0
+     *
+     * @link https://wordpress.org/plugins/ninja-forms/
+     *
+     * @return bool
+     */
+    public static function is_ninja_forms_preview(): bool {
+        return isset( $_GET['nf_preview_form'] ) && isset( $_GET['nf_iframe'] );
+    }
+
 }

--- a/pressidium-cookie-consent.php
+++ b/pressidium-cookie-consent.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pressidium Cookie Consent
  * Plugin URI: https://github.com/pressidium/pressidium-cookie-consent/
  * Description: Lightweight, user-friendly and customizable cookie consent banner to help you comply with the EU GDPR cookie law and CCPA regulations.
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: Pressidium
  * Author URI: https://pressidium.com/
  * Text Domain: pressidium-cookie-consent
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function setup_constants(): void {
     if ( ! defined( 'Pressidium\WP\CookieConsent\VERSION' ) ) {
-        define( 'Pressidium\WP\CookieConsent\VERSION', '1.8.0' );
+        define( 'Pressidium\WP\CookieConsent\VERSION', '1.8.1' );
     }
 
     if ( ! defined( 'Pressidium\WP\CookieConsent\PLUGIN_DIR' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -186,7 +186,7 @@ If you have spotted any bugs, or would like to request additional features from 
 
 == Changelog ==
 
-= 1.8.1: Oct 7, 2025 =
+= 1.8.1: Oct 16, 2025 =
 
 * Fix an issue with the names of the custom events pushed to the data layer for Google Tag Manager
 * Revert the modal headings to use `div` instead of `h2` to fix potential SEO issues

--- a/readme.txt
+++ b/readme.txt
@@ -186,6 +186,13 @@ If you have spotted any bugs, or would like to request additional features from 
 
 == Changelog ==
 
+= 1.8.1: Oct 7, 2025 =
+
+* Fix an issue with the names of the custom events pushed to the data layer for Google Tag Manager
+* Revert the modal headings to use `div` instead of `h2` to fix potential SEO issues
+* Remove no longer necessary `load_plugin_textdomain()` (plugins hosted on WordPress.org don't need it)
+* Integrate with Ninja Forms to prevent the cookie consent banner from loading on form previews
+
 = 1.8.0: May 5, 2025 =
 
 * Bump minimum required PHP version to 8.1

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: cookie, consent, gdpr, ccpa, cookies
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.1
-Stable Tag: 1.8.0
+Stable Tag: 1.8.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/src/client/lib/cookieconsent.js
+++ b/src/client/lib/cookieconsent.js
@@ -448,8 +448,10 @@
       if(consent_modal_title_value){
 
         if(!consent_modal_title){
-          consent_modal_title = _createNode('h2');
+          consent_modal_title = _createNode('div');
           consent_modal_title.id = 'c-ttl';
+          consent_modal_title.setAttribute('role', 'heading');
+          consent_modal_title.setAttribute('aria-level', '2');
           consent_modal_inner_inner.appendChild(consent_modal_title);
         }
 
@@ -570,7 +572,7 @@
         var settings = _createNode('div');
         var settings_container_inner = _createNode('div');
         settings_inner = _createNode('div');
-        settings_title = _createNode('h2');
+        settings_title = _createNode('div');
         var settings_header = _createNode('div');
         settings_close_btn = _createNode('button');
         settings_close_btn.appendChild(generateFocusSpan(2));
@@ -626,6 +628,7 @@
         settings_container.setAttribute('aria-modal', 'true');
         settings_container.setAttribute('aria-hidden', 'true');
         settings_container.setAttribute('aria-labelledby', 's-ttl');
+        settings_title.setAttribute('role', 'heading');
         settings_container.style.visibility = overlay.style.visibility = "hidden";
         overlay.style.opacity = 0;
 


### PR DESCRIPTION
* Fix an issue with the names of the custom events pushed to the data layer for Google Tag Manager
* Revert the modal headings to use `div` instead of `h2` to fix potential SEO issues
* Remove no longer necessary `load_plugin_textdomain()` (plugins hosted on WordPress.org don't need it)
* Integrate with Ninja Forms to prevent the cookie consent banner from loading on form previews