### PR TITLE
1.9.1

### DIFF
--- a/includes/AI/Gemini.php
+++ b/includes/AI/Gemini.php
@@ -108,6 +108,7 @@ final class Gemini extends AI {
             'models/gemini-2.0-flash',
             'models/gemini-2.0-flash-lite',
             'models/gemini-2.5-flash-lite',
+            'models/gemini-3-pro-preview',
         );
     }
 

--- a/pressidium-cookie-consent.php
+++ b/pressidium-cookie-consent.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pressidium Cookie Consent
  * Plugin URI: https://github.com/pressidium/pressidium-cookie-consent/
  * Description: Lightweight, user-friendly and customizable cookie consent banner to help you comply with the EU GDPR cookie law and CCPA regulations.
- * Version: 1.9.0
+ * Version: 1.9.1
  * Author: Pressidium
  * Author URI: https://pressidium.com/
  * Text Domain: pressidium-cookie-consent
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function setup_constants(): void {
     if ( ! defined( 'Pressidium\WP\CookieConsent\VERSION' ) ) {
-        define( 'Pressidium\WP\CookieConsent\VERSION', '1.9.0' );
+        define( 'Pressidium\WP\CookieConsent\VERSION', '1.9.1' );
     }
 
     if ( ! defined( 'Pressidium\WP\CookieConsent\PLUGIN_DIR' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: cookie, consent, gdpr, ccpa, cookies
 Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable Tag: 1.9.0
+Stable Tag: 1.9.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -189,6 +189,11 @@ If you have spotted any bugs, or would like to request additional features from 
 12. Pressidium Cookies Table block
 
 == Changelog ==
+
+= 1.9.1: Dec 9, 2025 =
+
+* Update “Tested up to” version to WordPress 6.9 to confirm compatibility
+* Update allowed AI models to include Gemini 3 Pro Preview
 
 = 1.9.0: Nov 17, 2025 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Plugin URI: https://pressidium.com/open-source/cookie-consent-plugin/
 Contributors: pressidium, overengineer
 Tags: cookie, consent, gdpr, ccpa, cookies
 Requires at least: 6.0
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 8.1
 Stable Tag: 1.9.0
 License: GPLv2 or later


### PR DESCRIPTION
* Update “Tested up to” version to WordPress 6.9 to confirm compatibility
* Update allowed AI models to include Gemini 3 Pro Preview