### PR TITLE
Prevent caching of REST API responses

### DIFF
--- a/includes/Integrations/Cache_Control.php
+++ b/includes/Integrations/Cache_Control.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Cache control integration.
+ *
+ * @author Konstantinos Pappas <konpap@pressidium.com>
+ * @copyright 2025 Pressidium
+ */
+
+namespace Pressidium\WP\CookieConsent\Integrations;
+
+use Pressidium\WP\CookieConsent\Hooks\Filters;
+
+use WP_REST_Response;
+use WP_REST_Server;
+use WP_REST_Request;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    die( 'Forbidden' );
+}
+
+/**
+ * Cache_Control class.
+ *
+ * Prevents caching of the plugin's REST API responses.
+ *
+ * LiteSpeed Cache (and QUIC.cloud CDN) caches GET REST API responses,
+ * which can cause stale settings to be returned after saving.
+ *
+ * @since 1.10.0
+ */
+class Cache_Control implements Filters {
+
+    /**
+     * @var string REST API namespace.
+     */
+    private const REST_NAMESPACE = '/pressidium-cookie-consent/v1';
+
+    /**
+     * Set no-cache headers on the REST API response.
+     *
+     * @param WP_REST_Response $result  Result to send to the client.
+     * @param WP_REST_Server   $server  The REST server instance.
+     * @param WP_REST_Request  $request The request that generated the response.
+     *
+     * @return WP_REST_Response
+     */
+    public function set_nocache_headers(
+        WP_REST_Response $result,
+        WP_REST_Server $server,
+        WP_REST_Request $request
+    ): WP_REST_Response {
+        $route = $request->get_route();
+
+        if ( ! str_starts_with( $route, self::REST_NAMESPACE ) ) {
+            return $result;
+        }
+
+        do_action( 'litespeed_control_set_nocache', 'pressidium cookie consent REST API response' );
+
+        $result->header( 'Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0' );
+
+        return $result;
+    }
+
+    /**
+     * Return the filters to register.
+     *
+     * @return array<string, array{0: string, 1?: int, 2?: int}>
+     */
+    public function get_filters(): array {
+        return array(
+            'rest_post_dispatch' => array( 'set_nocache_headers', 10, 3 ),
+        );
+    }
+
+}

--- a/includes/Integrations/Cache_Control.php
+++ b/includes/Integrations/Cache_Control.php
@@ -3,7 +3,7 @@
  * Cache control integration.
  *
  * @author Konstantinos Pappas <konpap@pressidium.com>
- * @copyright 2025 Pressidium
+ * @copyright 2026 Pressidium
  */
 
 namespace Pressidium\WP\CookieConsent\Integrations;

--- a/includes/Integrations/Service_Provider.php
+++ b/includes/Integrations/Service_Provider.php
@@ -36,6 +36,7 @@ class Service_Provider extends AbstractServiceProvider {
      */
     protected $provides = array(
         'wp_consent_api',
+        'cache_control',
     );
 
     /**
@@ -50,6 +51,9 @@ class Service_Provider extends AbstractServiceProvider {
     public function register(): void {
         $this->getContainer()
              ->add( 'wp_consent_api', WP_Consent_API::class );
+
+        $this->getContainer()
+             ->add( 'cache_control', Cache_Control::class );
     }
 
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -115,6 +115,7 @@ class Plugin {
             $hooks_manager->register( $this->container->get( 'feedback' ) );
             $hooks_manager->register( $this->container->get( 'cookies_block' ) );
             $hooks_manager->register( $this->container->get( 'wp_consent_api' ) );
+            $hooks_manager->register( $this->container->get( 'cache_control' ) );
         } catch ( ContainerExceptionInterface | NotFoundExceptionInterface $exception ) {
             $this->logger->log_exception( $exception );
         }


### PR DESCRIPTION
## Summary

Fixes https://github.com/pressidium/pressidium-cookie-consent/issues/150

LiteSpeed Cache (and QUIC.cloud CDN) caches GET REST API responses. When an admin saves plugin settings via POST, subsequent GET requests to `/wp-json/pressidium-cookie-consent/v1/settings` return stale cached data, making it appear that settings weren't saved.

This PR adds a `Cache_Control` integration that prevents any caching layer from caching the plugin's REST API responses — no manual cache exclusion rules needed.

## What it does

- Hooks into `rest_post_dispatch` to intercept responses for the `pressidium-cookie-consent/v1` namespace
- Fires LiteSpeed's `litespeed_control_set_nocache` action (graceful no-op when LiteSpeed is not installed)
- Adds standard `Cache-Control: no-store, no-cache, must-revalidate, max-age=0` headers, which protects against any caching layer (LiteSpeed, Cloudflare, Varnish, WP Rocket, browser cache, etc.)

## Why this is safe for frontend performance

- The frontend cookie consent banner does **not** make REST API calls to load settings — settings are already inlined via `wp_localize_script()`
- The only frontend REST call is a `POST /consent` to record user consent, which is never cached anyway
- All GET-cacheable routes (`/settings`, `/logs`, `/consents`, `/export`, `/ai/*`) are admin-only endpoints
- Overhead is a single `str_starts_with()` call per REST API request

## Changes

- **New:** `includes/Integrations/Cache_Control.php` — implements the `Filters` interface
- **Modified:** `includes/Integrations/Service_Provider.php` — registers the new class
- **Modified:** `includes/Plugin.php` — hooks it into the hooks manager

## Test plan

- [x] With LiteSpeed Cache active: save settings, refresh the settings page, verify new settings appear
- [x] Without LiteSpeed Cache: verify plugin works normally (no errors, no side effects)
- [x] Verify REST API responses include `Cache-Control: no-store, no-cache, must-revalidate, max-age=0` header